### PR TITLE
Update parser version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/jaystack/odata-v4-mysql#readme",
   "dependencies": {
-    "odata-v4-parser": "0.1.13",
+    "odata-v4-parser": "^0.1.13",
     "odata-v4-sql": "^0.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The parser version used is not up to date and caused unexpected character error while there's nothing wrong with the odata syntax. Update the version fixed the issue.